### PR TITLE
Add website traffic checker

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,18 @@
     <title>Unknown AI</title>
 </head>
 <body>
-    
+    <h1>Welcome to Unknown AI</h1>
+    <p>Your gateway to discovering AI technologies.</p>
+    <p>Total visits: <span id="visit-count"></span></p>
+
+    <script>
+        // Increment and display visit count using CountAPI
+        fetch('https://api.countapi.xyz/hit/unknownai/visits')
+            .then(response => response.json())
+            .then(data => {
+                document.getElementById('visit-count').innerText = data.value;
+            })
+            .catch(err => console.error('Failed to fetch visit count', err));
+    </script>
 </body>
 </html>

--- a/traffic_checker.py
+++ b/traffic_checker.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Simple website traffic checker using CountAPI.
+
+This script uses only Python's standard library to retrieve or increment
+visit counts for a given key. Embed the same key in your webpage to track
+visits and query it from the command line.
+"""
+
+import argparse
+import json
+import urllib.parse
+import urllib.request
+
+
+def fetch_json(url: str) -> dict:
+    with urllib.request.urlopen(url, timeout=10) as response:
+        return json.loads(response.read().decode())
+
+
+def get_count(key: str) -> int:
+    url = f"https://api.countapi.xyz/get/{urllib.parse.quote(key)}"
+    data = fetch_json(url)
+    return data.get("value", 0)
+
+
+def hit(key: str) -> int:
+    url = f"https://api.countapi.xyz/hit/{urllib.parse.quote(key)}"
+    data = fetch_json(url)
+    return data.get("value", 0)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check website traffic using CountAPI")
+    parser.add_argument("key", help="Unique key identifying the site, e.g. 'unknownai/visits'")
+    parser.add_argument(
+        "--increment",
+        action="store_true",
+        help="Increment the counter before retrieving the count",
+    )
+    args = parser.parse_args()
+
+    count = hit(args.key) if args.increment else get_count(args.key)
+    print(f"Total visits for {args.key}: {count}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Display visit counts on the landing page using CountAPI
- Provide a Python script to retrieve or increment website visit counts

## Testing
- `python3 traffic_checker.py 'unknownai/visits' --increment` *(fails: URLError Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a57640c1048326b22ac8931c2259f3