### PR TITLE
Add website traffic checker with styled landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,29 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Unknown AI</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    
+    <header class="hero">
+        <h1>Unknown AI</h1>
+        <p>Discover the limitless possibilities of artificial intelligence.</p>
+    </header>
+    <section class="counter">
+        <p>Total visits: <span id="visit-count"></span></p>
+    </section>
+    <footer>
+        <p>&copy; 2024 Unknown AI</p>
+    </footer>
+    <script>
+        // Increment and display visit count using CountAPI
+        fetch('https://api.countapi.xyz/hit/unknownai/visits')
+            .then(response => response.json())
+            .then(data => {
+                document.getElementById('visit-count').innerText = data.value;
+            })
+            .catch(err => console.error('Failed to fetch visit count', err));
+    </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,40 @@
+body {
+    margin: 0;
+    font-family: 'Roboto', sans-serif;
+    color: #333;
+    display: flex;
+    min-height: 100vh;
+    flex-direction: column;
+}
+
+.hero {
+    background: linear-gradient(135deg, #6a11cb 0%, #2575fc 100%);
+    color: #fff;
+    padding: 80px 20px;
+    text-align: center;
+}
+
+.hero h1 {
+    margin: 0;
+    font-size: 3rem;
+}
+
+.hero p {
+    font-weight: 300;
+    font-size: 1.25rem;
+    margin-top: 1rem;
+}
+
+.counter {
+    text-align: center;
+    margin: 40px 0;
+    font-size: 1.2rem;
+}
+
+footer {
+    margin-top: auto;
+    background: #f5f5f5;
+    text-align: center;
+    padding: 20px 0;
+    font-size: 0.9rem;
+}

--- a/traffic_checker.py
+++ b/traffic_checker.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Simple website traffic checker using CountAPI.
+
+This script uses only Python's standard library to retrieve or increment
+visit counts for a given key. Embed the same key in your webpage to track
+visits and query it from the command line.
+"""
+
+import argparse
+import json
+import urllib.parse
+import urllib.request
+
+
+def fetch_json(url: str) -> dict:
+    with urllib.request.urlopen(url, timeout=10) as response:
+        return json.loads(response.read().decode())
+
+
+def get_count(key: str) -> int:
+    url = f"https://api.countapi.xyz/get/{urllib.parse.quote(key)}"
+    data = fetch_json(url)
+    return data.get("value", 0)
+
+
+def hit(key: str) -> int:
+    url = f"https://api.countapi.xyz/hit/{urllib.parse.quote(key)}"
+    data = fetch_json(url)
+    return data.get("value", 0)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Check website traffic using CountAPI")
+    parser.add_argument("key", help="Unique key identifying the site, e.g. 'unknownai/visits'")
+    parser.add_argument(
+        "--increment",
+        action="store_true",
+        help="Increment the counter before retrieving the count",
+    )
+    args = parser.parse_args()
+
+    count = hit(args.key) if args.increment else get_count(args.key)
+    print(f"Total visits for {args.key}: {count}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Display visit counts on the landing page using CountAPI
- Provide a Python script to retrieve or increment website visit counts
- Style the landing page with a hero section, custom fonts and responsive layout

## Testing
- `python3 -m py_compile traffic_checker.py`
- `python3 traffic_checker.py 'unknownai/visits' --increment` *(fails: URLError Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a57640c1048326b22ac8931c2259f3